### PR TITLE
Allow `object` *or* `string` for `datasource` properties

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -332,7 +332,7 @@ datastream originates.
 | `deployment.properties.unitOfOffsets.name` | The name of the unit. | String | Zero-to-one |
 | `deployment.properties.unitOfOffsets.symbol` | The symbol for the unit. | String | Zero-to-one |
 | `deployment.properties.unitOfOffsets.definition` | URL to the definition of the unit. | String | Zero-to-one |
-| `dataSource` | A descriptive string indicating the source of the data. | String | Zero-to-one |
+| `dataSource` | A descriptive string or any JSON object indicating the source of the data. | String / Object | Zero-to-one |
 ```
 
 *Example*: Additional information for a *Datastream*
@@ -508,7 +508,7 @@ for the OGC SensorThings API (STA) `Observation` entity.
 | `@context.@import` | Import URL for the STAMPLATE context. | String | One (mandatory) |
 | `@context.@vocab` | The default vocabulary used (schema.org). | String | One (mandatory) |
 | `jsonld.type` | The type of the object, in this case 'ObservationProperties'. | String | One (mandatory) |
-| `dataSource` | A descriptive string indicating the source of the observation data. | String | Zero-to-one |
+| `dataSource` | A descriptive string or any JSON object indicating the source of the observation data. | String / Object | Zero-to-one |
 ```
 
 *Example*: Additional information for an *Observation*

--- a/examples/datastream_properties.json
+++ b/examples/datastream_properties.json
@@ -86,5 +86,10 @@
       }
     }
   },
-  "dataSource": "ftp/uploads01"
+  "datasource": {
+    "thingId": "proj01",
+    "thingName": "climate station of project 01",
+    "datasourceId": "database_instance:01",
+    "datastreamId": "Battery_Voltage_Raw"
+  }
 }

--- a/examples/datastream_properties.json
+++ b/examples/datastream_properties.json
@@ -86,7 +86,7 @@
       }
     }
   },
-  "datasource": {
+  "dataSource": {
     "thingId": "proj01",
     "thingName": "climate station of project 01",
     "datasourceId": "database_instance:01",

--- a/schemas/datastream_properties.schema.json
+++ b/schemas/datastream_properties.schema.json
@@ -338,7 +338,15 @@
     },
     "dataSource": {
       "description": "additional information on the source of the datastream data, e.g., an upload folder",
-      "type": "string"
+      "anyOf": [
+          {
+              "type": "string"
+          },
+          {
+              "type": "object",
+              "additionalProperties": true
+          }
+      ]
     }
   },
   "required": [

--- a/schemas/observation_properties.schema.json
+++ b/schemas/observation_properties.schema.json
@@ -31,7 +31,15 @@
     },
     "dataSource": {
       "description": "additional information on the source of the observation, e.g., a file name",
-      "type": "string"
+      "anyOf": [
+          {
+              "type": "string"
+          },
+          {
+              "type": "object",
+              "additionalProperties": true
+          }
+      ]
     }
   },
   "required": [


### PR DESCRIPTION
Goal of this request:

- allow the types `string` *or* `object` for the `datasource` properties.

**Examples:**

Just a `string`:

```json
{
  // ...
  "dataSource": "project01/example.csv"
}
```

Using an `object`:

```json
{
  // ...
  "dataSource": {
    "thingId": "proj01",
    "thingName": "climate station of project 01",
    "datasourceId": "database_instance:01",
    "datastreamId": "Battery_Voltage_Raw"
  }
}
```

Note: the object can be any simple JSON object.